### PR TITLE
patch missing level 2+ in-progress class

### DIFF
--- a/app.js
+++ b/app.js
@@ -204,11 +204,12 @@ function checkOffCompetencies() {
         let id = name2Id(skill)
         let level = parseInt(personValues[skill])
         $('.' + id).each((i, el) => {
+	    let targetLevel = parseInt($(el).attr('level'))
             $('.drive-link', $(el)).hide();
-            if (level === 0) {
+            if (level === 0 || level < targetLevel) {
                 $(el).addClass('in-progress')
             }
-            if (parseInt($(el).attr('level')) <= level) {
+            if (targetLevel <= level) {
                 $(el).addClass('complete')
                 $(el).prepend('<i class="fas fa-check"></i> ')
             }

--- a/app.js
+++ b/app.js
@@ -204,7 +204,7 @@ function checkOffCompetencies() {
         let id = name2Id(skill)
         let level = parseInt(personValues[skill])
         $('.' + id).each((i, el) => {
-	    let targetLevel = parseInt($(el).attr('level'))
+            let targetLevel = parseInt($(el).attr('level'))
             $('.drive-link', $(el)).hide();
             if (level === 0 || level < targetLevel) {
                 $(el).addClass('in-progress')


### PR DESCRIPTION
Competencies which have level 1 completed did not properly add the `in-progress` class to pills for level 2 and beyond.

Note the GitHub Levels 1 and 2 pills in the attached screenshot, the level 1 pill is completed, the level 2 pill is grey with no `+` plus button to add it as in-progress:
![Screen Shot 2020-01-22 at 10 07 19 AM](https://user-images.githubusercontent.com/28075076/72905745-ffd91d00-3cfe-11ea-96ed-106df9903f2e.png)
