### PR TITLE
Add support for group levels

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d h1:yKm7XZV6j9
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/main.go
+++ b/main.go
@@ -331,7 +331,7 @@ func getLevelFromName(name string) (string, string) {
 var competencies []string
 
 func createGroup(count string, group string) (string, error) {
-	group, _ = getLevelFromName(group)
+	group, level := getLevelFromName(group)
 
 	result := "<table class=\"group mt-4\"><tr><td valign=\"top\"><span class=\"group-heading text-sm pr-2 whitespace-no-wrap\">" + group + " (" + count + " of)" + "</span></td><td class=\"group\" valign=\"top\"> "
 	if len(competencies) == 0 {
@@ -346,6 +346,9 @@ func createGroup(count string, group string) (string, error) {
 	for _, competency := range competencies {
 		if strings.HasPrefix(competency, strings.ToLower(strings.ReplaceAll(group, " ", "-"))+"-") {
 			competency = competency[0 : len(competency)-3]
+			if level != "1" {
+				competency += ":" + level
+			}
 			link := createSkillLink(competency, false)
 			result += link
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1,17 +1,24 @@
 package main
 
 import (
-	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	log.SetOutput(ioutil.Discard)
+	os.Exit(m.Run())
+}
 
 func TestProcessInherited(t *testing.T) {
 	result, err := processInherits("#original \n##Skills\n<inherit doc=\"../test1.md\"/>\n   a  ", false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(result)
+	log.Println(result)
 	require.Equal(t, "#original \n##Skills\n<skills>\nbreakdancing\n</skills>\n<skills>\nfigure skating\n</skills>\n<skills>\nkung fu\n</skills>\n   a", result)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -19,7 +19,6 @@ func TestProcessInherited(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Println(result)
 	require.Equal(t, "#original \n##Skills\n<skills>\nbreakdancing\n</skills>\n<skills>\nfigure skating\n</skills>\n<skills>\nkung fu\n</skills>\n   a", result)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -22,3 +22,9 @@ func TestProcessInherited(t *testing.T) {
 	log.Println(result)
 	require.Equal(t, "#original \n##Skills\n<skills>\nbreakdancing\n</skills>\n<skills>\nfigure skating\n</skills>\n<skills>\nkung fu\n</skills>\n   a", result)
 }
+
+func TestCreateGroup(t *testing.T) {
+	result, err := createGroup("10", "something")
+	require.NoError(t, err)
+	require.Equal(t, "<table class=\"group mt-4\"><tr><td valign=\"top\"><span class=\"group-heading text-sm pr-2 whitespace-no-wrap\">something (10 of)</span></td><td class=\"group\" valign=\"top\"> </td></tr></table>", result)
+}


### PR DESCRIPTION
Using example skill block:
```markdown
<skills>
Github:2 
Diagrams 
2 of Language:2
</skills>
```

Before:
![Screen Shot 2020-08-18 at 12 09 25 PM](https://user-images.githubusercontent.com/28075076/90537974-e93b5d00-e14b-11ea-97af-be9532e6cbb9.png)

After:
![Screen Shot 2020-08-18 at 12 09 07 PM](https://user-images.githubusercontent.com/28075076/90537998-ef313e00-e14b-11ea-930e-2f9468a3d510.png)

Where level 1 or no level still displays without a level indicator.

([ticket](https://app.asana.com/0/1160395709536137/1185341392520683/f))