### PR TITLE
Inherit Skills Headings

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func tailwind(html []byte) []byte {
 	htmlString = strings.ReplaceAll(htmlString, "<h1>", `<h1 class="whitespace-no-wrap top-0 left-0 fixed w-full block opacity-90 bg-white p-2 px-8 border-b-2 text-lg mb-4"><img class="w-6 inline-block mr-3" src="seedling.png">`)
 	htmlString = strings.ReplaceAll(htmlString, "<h2>", `<h2 class="px-2 text-2xl mt-4">`)
 	htmlString = strings.ReplaceAll(htmlString, "<h3>", `<h3 class="px-2 text-xl mt-2">`)
+	htmlString = strings.ReplaceAll(htmlString, "<h4>", `<h4 class="px-2 text-l mt-2">`)
 	htmlString = strings.ReplaceAll(htmlString, "<p>", `<p style="width:50rem" class="px-2">`)
 	return []byte(htmlString)
 }
@@ -162,6 +163,7 @@ func googleHireify(html string) string {
 	html = strings.ReplaceAll(strings.ReplaceAll(html, "<h1>", "<strong>"), "</h1>", "</strong><br><br>")
 	html = strings.ReplaceAll(strings.ReplaceAll(html, "<h2>", "<strong>"), "</h2>", "</strong><br>")
 	html = strings.ReplaceAll(strings.ReplaceAll(html, "<h3>", "<strong>"), "</h3>", "</strong><br>")
+	html = strings.ReplaceAll(strings.ReplaceAll(html, "<h4>", "<br><strong>"), "</h4>", "</strong><br>")
 	html = strings.ReplaceAll(strings.ReplaceAll(html, "<b>", "<strong>"), "</b>", "</strong>")
 	html = strings.ReplaceAll(html, "</p>", "</p><br>")
 	// html = strings.ReplaceAll(html, ": level 2", "")
@@ -229,8 +231,8 @@ func processInherits(text string, skipBase bool) (string, error) {
 func flatten(skillSets []skillSet) string {
 	result := ""
 	for _, skillSet := range skillSets {
-		result += `<h3 class="m-0 px-2">` + skillSet.name + ` skills</h3>` + "\n"
-		result += skillSet.skills + "\n"
+		result += `<h4>` + skillSet.name + ` skills</h4>` + "\n\n"
+		result += skillSet.skills + "\n\n"
 	}
 	return strings.TrimSpace(result)
 }


### PR DESCRIPTION
With the changes in https://github.com/searchspring/competencies/pull/94 - I felt the skill blocks needed labels for what they were (eg: base, engineering-base, etc...). This PR adds these headers and makes these blocks have more context.

![image](https://user-images.githubusercontent.com/5060400/143258920-55eec3d2-8f4c-46b7-91d2-9fd6981c5a2c.png)
